### PR TITLE
Fix editor warnings to use ScriptableObject.CreateInstance

### DIFF
--- a/Packages/com.sylan.gmmenu/Editor/GMMenuInitialize.cs
+++ b/Packages/com.sylan.gmmenu/Editor/GMMenuInitialize.cs
@@ -6,14 +6,14 @@ using VRC.SDKBase.Editor.BuildPipeline;
 namespace Sylan.GMMenu
 {
     [InitializeOnLoad]
-    public class GMMenuInitialize : Editor, IVRCSDKBuildRequestedCallback
+    public class GMMenuInitialize : IVRCSDKBuildRequestedCallback
     {
         private static bool SetSerializedProperties()
         {
             //Object with Serialized Property(s)
             if (!SerializedPropertyUtils.GetSerializedObjects<GMMenuPart>(out SerializedObject[] serializedObjects)) return false;
 
-            foreach(SerializedObject serializedObject in serializedObjects)
+            foreach (SerializedObject serializedObject in serializedObjects)
             {
                 //Set Serialized Property
                 SerializedPropertyUtils.PopulateSerializedProperty<GMMenu>(serializedObject, GMMenuPart.GMMenuPropertyName);

--- a/Packages/com.sylan.gmmenu/Editor/GMMenuOptionalEditor.cs
+++ b/Packages/com.sylan.gmmenu/Editor/GMMenuOptionalEditor.cs
@@ -7,7 +7,7 @@ using VRC.SDKBase.Editor.BuildPipeline;
 namespace Sylan.GMMenu
 {
     [InitializeOnLoad]
-    public class GMMenuOptionalInitialize : Editor, IVRCSDKBuildRequestedCallback
+    public class GMMenuOptionalInitialize : IVRCSDKBuildRequestedCallback
     {
         private static bool SetSerializedProperties()
         {
@@ -17,7 +17,7 @@ namespace Sylan.GMMenu
             {
                 //Set Serialized Property
                 SerializedPropertyUtils.PopulateSerializedProperty<AudioSettingManager>(serializedObject, VoiceModeManager.AudioSettingManagerPropertyName);
-                flag = true;            
+                flag = true;
             }
 
             if (SerializedPropertyUtils.GetSerializedObject<GMWhisperManager>(out serializedObject))
@@ -35,7 +35,7 @@ namespace Sylan.GMMenu
             }
 
             return flag;
-            
+
         }
         //
         //Run On Play

--- a/Packages/com.sylan.gmmenu/Editor/SerializedPropertyUtils.cs
+++ b/Packages/com.sylan.gmmenu/Editor/SerializedPropertyUtils.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace Sylan.GMMenu.EditorUtilities
 {
-    public class SerializedPropertyUtils : Editor
+    public static class SerializedPropertyUtils
     {
         /// <summary>
         /// Find exactly one object of Type T in the scene hierarchy.
@@ -38,7 +38,7 @@ namespace Sylan.GMMenu.EditorUtilities
             return true;
         }
         /// <summary>
-        /// Set Serialized Property of Type T. Property must not be an array. 
+        /// Set Serialized Property of Type T. Property must not be an array.
         /// </summary>
         /// <typeparam name="T">Type of Object to set</typeparam>
         /// <param name="serializedObject">Object with the property</param>
@@ -64,7 +64,7 @@ namespace Sylan.GMMenu.EditorUtilities
         /// <param name="propertyName">Name of Serialized Property</param>
         public static void PopulateSerializedArray<T>(SerializedObject serializedObject, string propertyName) where T : MonoBehaviour
         {
-            if(serializedObject == null) return;
+            if (serializedObject == null) return;
             SerializedProperty arrayProperty;
             arrayProperty = serializedObject.FindProperty(propertyName);
 
@@ -95,7 +95,7 @@ namespace Sylan.GMMenu.EditorUtilities
                 EditorApplication.isPlaying = false;
                 return false;
             }
-            if(obj != null) serializedObject = new SerializedObject(obj);
+            if (obj != null) serializedObject = new SerializedObject(obj);
             return true;
         }
         /// <summary>

--- a/Packages/com.sylan.gmmenu/Runtime/Teleporter/TeleportButton.cs
+++ b/Packages/com.sylan.gmmenu/Runtime/Teleporter/TeleportButton.cs
@@ -26,7 +26,7 @@ namespace Sylan.GMMenu
 
 #if !COMPILER_UDONSHARP && UNITY_EDITOR
 [InitializeOnLoad]
-public class DoorSyncInitialize : Editor, IVRCSDKBuildRequestedCallback
+public class DoorSyncInitialize : IVRCSDKBuildRequestedCallback
 {
     private static bool SetSerializedProperties()
     {
@@ -95,7 +95,7 @@ public class DoorSyncInitialize : Editor, IVRCSDKBuildRequestedCallback
         return true;
     }
     /// <summary>
-    /// Set Serialized Property of Type T. Property must not be an array. 
+    /// Set Serialized Property of Type T. Property must not be an array.
     /// </summary>
     /// <typeparam name="T">Type of Object to set</typeparam>
     /// <param name="serializedObject">Object with the property</param>


### PR DESCRIPTION
Example warning:
```
Sylan.AudioManager.AudioSettingManagerInitialize must be instantiated using the ScriptableObject.CreateInstance method instead of new AudioSettingManagerInitialize.
UnityEditor.Editor:.ctor ()
Sylan.AudioManager.AudioSettingManagerInitialize:.ctor ()
System.Activator:CreateInstance (System.Type)
VRC.SDKBase.Editor.BuildPipeline.VRCBuildPipelineCallbacks:Initialize ()
UnityEditor.EditorAssemblies:ProcessInitializeOnLoadMethodAttributes ()
```
This was caused by classes deriving from the `Editor` class as well as implementing the `IVRCSDKBuildRequestedCallback` interface. The `Editor` base class is specifically used for implementing custom inspectors, which was not the case here.