### PR TITLE
Fix no clip in full body "locking" IRL head rotation

### DIFF
--- a/Packages/com.sylan.gmmenu/Runtime/Navigation/PlayerMover.cs
+++ b/Packages/com.sylan.gmmenu/Runtime/Navigation/PlayerMover.cs
@@ -1,5 +1,6 @@
 ﻿
 using System;
+using Sylan.GMMenu.Utils;
 using UdonSharp;
 using UnityEngine;
 using VRC.SDKBase;
@@ -98,7 +99,7 @@ namespace Sylan.GMMenu
         public void UpdateStationPosition()
         {
             if (!noclip) return;
-            //Don't teleport while staying still. 
+            //Don't teleport while staying still.
             bool isStill = (speedHorizontal == 0 && speedVertical == 0 && speedLongitudinal == 0);
             if (!isStill)
             {
@@ -108,10 +109,9 @@ namespace Sylan.GMMenu
                 offset += speedVertical * (headVector * Vector3.up);
                 offset *= speedMagnitude * Time.deltaTime;
                 station.position += offset;
-                //localPlayer.TeleportTo(
-                TeleportPlayer(
+                TeleportUtils.RoomAlignedTeleport(
                     localPlayer,
-                    station.position, 
+                    station.position,
                     localPlayer.GetRotation(),
                     true
                     );
@@ -119,8 +119,7 @@ namespace Sylan.GMMenu
             }
             if (!menuToggle.MenuState())
             {
-                //localPlayer.TeleportTo(
-                TeleportPlayer(
+                TeleportUtils.RoomAlignedTeleport(
                     localPlayer,
                     station.position,
                     localPlayer.GetRotation(),
@@ -130,24 +129,6 @@ namespace Sylan.GMMenu
             }
             localPlayer.SetVelocity(Vector3.zero);
             return;
-
-        }
-        public void TeleportPlayer(VRCPlayerApi player, Vector3 teleportPos, Quaternion teleportRotation, bool lerpOnRemote)
-        {
-            //This function teleports the player,
-            //calculates the difference between the expected rotation and the actual rotation resulting from the teleport.
-            //then teleports the player again to compensate for the error.
-            //This is temporary patch for a problem where noclip causes one to spin rapidly, until I can figure out what is causing this to happen
-            player.TeleportTo(
-                teleportPos,
-                teleportRotation,
-                VRC_SceneDescriptor.SpawnOrientation.AlignPlayerWithSpawnPoint,
-                lerpOnRemote
-                );
-            player.TeleportTo(teleportPos,
-                Quaternion.Inverse(localPlayer.GetRotation()) * teleportRotation * teleportRotation, 
-                VRC_SceneDescriptor.SpawnOrientation.AlignPlayerWithSpawnPoint,
-                lerpOnRemote);
         }
         public void ToggleNoclip()
         {

--- a/Packages/com.sylan.gmmenu/Runtime/Utils/TeleportUtils.cs
+++ b/Packages/com.sylan.gmmenu/Runtime/Utils/TeleportUtils.cs
@@ -1,0 +1,78 @@
+/*
+Teleports the player using GetPosition and GetRotation as the basis for
+the interface, but does all the math to teleport by TrackingData origin
+under the hood correctly. This gives it a solid, reliable teleport suitable
+for seamless teleportation use cases, while giving you an interface that
+still has an easy to use pivot point and forward axis.
+
+Copyright (c) 2023 @Phasedragon on GitHub
+Additional help by @Nestorboy
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+using UnityEngine;
+using VRC.SDKBase;
+
+namespace Sylan.GMMenu.Utils
+{
+    public static class TeleportUtils
+    {
+        /// <summary>
+        /// <para>See: https://gist.github.com/Phasedragon/5b76edfb8723b6bc4a49cd43adde5d3d</para>
+        /// </summary>
+        /// <param name="teleportRot">Gets projected onto the Y plane.</param>
+        public static void RoomAlignedTeleport(VRCPlayerApi player, Vector3 teleportPos, Quaternion teleportRot, bool lerpOnRemote)
+        {
+#if UNITY_EDITOR
+            // Skip process and Exit early for ClientSim since there is no play space to orient.
+            player.TeleportTo(teleportPos, teleportRot);
+#else
+            // This is absolutely not how you are supposed to use euler angles. Converting a quaternion to
+            // euler angles, taking some component of that and then converting that back to a quaternion is
+            // asking for trouble, and that is exactly what is happening here. However through some miracle
+            // this case actually behaves correctly, and I (JanSharp) believe that it's related to the order
+            // that the euler axis get processed by Unity. Supposedly it is YXZ around local axis and ZXY
+            // around world axis. So maybe these functions here use YXZ and that's why it works.
+            teleportRot = Quaternion.Euler(0, teleportRot.eulerAngles.y, 0);
+
+            // Get player pos/rot
+            Vector3 playerPos = player.GetPosition();
+            Quaternion invPlayerRot = Quaternion.Inverse(player.GetRotation());
+
+            // Get origin pos/rot
+            VRCPlayerApi.TrackingData origin = player.GetTrackingData(VRCPlayerApi.TrackingDataType.Origin);
+
+            // Subtract player from origin in order to get the offset from the player to the origin
+            // offset = origin - player
+            Vector3 offsetPos = origin.position - playerPos;
+            Quaternion offsetRot = invPlayerRot * origin.rotation;
+
+            // Add the offset onto the destination in order to construct a pos/rot of where your origin would be in order to put the player at the destination
+            // target = destination + offset
+            player.TeleportTo(
+                teleportPos + teleportRot * invPlayerRot * offsetPos,
+                teleportRot * offsetRot,
+                VRC_SceneDescriptor.SpawnOrientation.AlignRoomWithSpawnPoint,
+                lerpOnRemote);
+#endif
+        }
+    }
+}

--- a/Packages/com.sylan.gmmenu/Runtime/Utils/TeleportUtils.cs.meta
+++ b/Packages/com.sylan.gmmenu/Runtime/Utils/TeleportUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 08d42dd6d8ef516d99f9d28cfbbac1c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Specifically when using full body, turning the head to the left would not actually rotate the view point to the left, but rather rotate the avatar, kind of like the rest of the body, the opposite direction such that the view point kept the the exact same 
horizontal rotation.

I've recently found this little [teleport wrapper function](https://gist.github.com/Phasedragon/5b76edfb8723b6bc4a49cd43adde5d3d), and it turns out using that wrapper fixes the issue.

I've tested 6 teleport function variants for the sake of it, 3 using `AlignPlayerWithSpawnPoint`, 3 using `AlignRoomWithSpawnPoint`.

- Just raw VRCPlayerApi.TeleportTo
- VRCPlayerApi.TeleportTo, but with a corrective teleport afterwards (just like the current implementation)
- The linked teleport wrapper

The results:
- raw `AlignPlayerWithSpawnPoint`: spinning
- corrected `AlignPlayerWithSpawnPoint`: head "lock" as described
- wrapper but using `AlignPlayerWithSpawnPoint`: as expected horribly wrong, was like a helicopter
- raw `AlignRoomWithSpawnPoint`: I forget what happened with this one... maybe also helicopter, idk, something was wrong
- corrected `AlignRoomWithSpawnPoint`: surprisingly good. No head "lock", no spinning, only oddity being that entering no clip would move you to the side by ~1 meter. For whatever reason
- wrapper using `AlignRoomWithSpawnPoint` as it should: no issues