### PR TITLE
Move GMMenuPart back out of the Sylan.GMMenu namespace

### DIFF
--- a/Packages/com.sylan.gmmenu/Runtime/GMMenuPart.cs
+++ b/Packages/com.sylan.gmmenu/Runtime/GMMenuPart.cs
@@ -1,12 +1,12 @@
 ﻿using UdonSharp;
 using UnityEngine;
 
-namespace Sylan.GMMenu
+[UdonBehaviourSyncMode(BehaviourSyncMode.None)]
+public class GMMenuPart : UdonSharpBehaviour
 {
-    [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
-    public class GMMenuPart : UdonSharpBehaviour
-    {
-        [HideInInspector, SerializeField] public GMMenu gmMenu;
-        public const string GMMenuPropertyName = nameof(gmMenu);
-    }
+    // Using a 'using Sylan.GMMenu;' made UdonSharp fail to compile, claiming that GMMenu is a namespace that
+    // is being used as a type, but only if it was compiling without the audio manager package present.
+    // That makes just about zero sense but it is what it is.
+    [HideInInspector, SerializeField] public Sylan.GMMenu.GMMenu gmMenu;
+    public const string GMMenuPropertyName = nameof(gmMenu);
 }


### PR DESCRIPTION
I changed this in the optional audio manager PR because it caused a weird UdonSharp compilation error, as described in the added comment.

However moving the class into the namespace is a breaking change for anybody who was using the class in their own scripts, so this is probably the preferable way to resolve this compilation error.

Again sorry for forgetting when making the original PR!