### PR TITLE
Prevent objects such as pickups colliding with the menu

### DIFF
--- a/Packages/com.sylan.gmmenu/Samples/Prefab/GMMenu.prefab
+++ b/Packages/com.sylan.gmmenu/Samples/Prefab/GMMenu.prefab
@@ -14265,6 +14265,7 @@ GameObject:
   - component: {fileID: 1352804965494925908}
   - component: {fileID: 1352804965494925900}
   - component: {fileID: 1352804965494925907}
+  - component: {fileID: 2562317735583596719}
   m_Layer: 13
   m_Name: WatchCameraPanel
   m_TagString: Untagged
@@ -14345,6 +14346,27 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!65 &2562317735583596719
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1352804965494925905}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_LayerOverridePriority: 10
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 720, y: 720, z: 1}
+  m_Center: {x: 360, y: -360, z: 0}
 --- !u!1 &1352804965500659039
 GameObject:
   m_ObjectHideFlags: 0
@@ -17112,8 +17134,8 @@ BoxCollider:
     m_Bits: 0
   m_ExcludeLayers:
     serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
+    m_Bits: 4294967295
+  m_LayerOverridePriority: 10
   m_IsTrigger: 0
   m_ProvidesContacts: 0
   m_Enabled: 1
@@ -34239,6 +34261,7 @@ GameObject:
   - component: {fileID: 3576604230016489925}
   - component: {fileID: 3576604230016489924}
   - component: {fileID: 3576604230016489931}
+  - component: {fileID: 466287964812649917}
   m_Layer: 13
   m_Name: BottomBar
   m_TagString: Untagged
@@ -34317,6 +34340,27 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!65 &466287964812649917
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3576604230016489929}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_LayerOverridePriority: 10
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 800, y: 75, z: 1}
+  m_Center: {x: 400, y: -37.5, z: 0}
 --- !u!1 &3576604230019876156
 GameObject:
   m_ObjectHideFlags: 0

--- a/Packages/com.sylan.gmmenu/Samples/Prefab/GMMenu.prefab
+++ b/Packages/com.sylan.gmmenu/Samples/Prefab/GMMenu.prefab
@@ -14266,6 +14266,7 @@ GameObject:
   - component: {fileID: 1352804965494925900}
   - component: {fileID: 1352804965494925907}
   - component: {fileID: 2562317735583596719}
+  - component: {fileID: 6658565611929123222}
   m_Layer: 13
   m_Name: WatchCameraPanel
   m_TagString: Untagged
@@ -14367,6 +14368,33 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 720, y: 720, z: 1}
   m_Center: {x: 360, y: -360, z: 0}
+--- !u!54 &6658565611929123222
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1352804965494925905}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1 &1352804965500659039
 GameObject:
   m_ObjectHideFlags: 0
@@ -15460,6 +15488,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1352804965597205549}
   - component: {fileID: 1352804965597205551}
+  - component: {fileID: 3547697873362918867}
   m_Layer: 0
   m_Name: Station
   m_TagString: Untagged
@@ -15503,6 +15532,33 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 0.1, y: 0.01, z: 0.1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &3547697873362918867
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1352804965597205548}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1 &1352804965614542958
 GameObject:
   m_ObjectHideFlags: 0
@@ -16977,6 +17033,7 @@ GameObject:
   - component: {fileID: 1352804965763847975}
   - component: {fileID: 1352804965763847974}
   - component: {fileID: 1352804965763847981}
+  - component: {fileID: 1208364929297620543}
   m_Layer: 13
   m_Name: GMCanvas
   m_TagString: Untagged
@@ -17142,6 +17199,33 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 800, y: 600, z: 0}
   m_Center: {x: 400, y: 300, z: 0.5}
+--- !u!54 &1208364929297620543
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1352804965763847972}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1 &1352804965765610641
 GameObject:
   m_ObjectHideFlags: 0
@@ -34262,6 +34346,7 @@ GameObject:
   - component: {fileID: 3576604230016489924}
   - component: {fileID: 3576604230016489931}
   - component: {fileID: 466287964812649917}
+  - component: {fileID: 798631895724104385}
   m_Layer: 13
   m_Name: BottomBar
   m_TagString: Untagged
@@ -34361,6 +34446,33 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 800, y: 75, z: 1}
   m_Center: {x: 400, y: -37.5, z: 0}
+--- !u!54 &798631895724104385
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3576604230016489929}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1 &3576604230019876156
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
This PR is 2 in 1 unfortunately. I wanted to do them separately but that would cause merge conflicts that I don't want to make you deal with.

One is as the title says. Some notes regarding that:
- the `VRC UI Shape` component automatically adds a box collider at runtime if there isn't one on the object yet
  - there are 3 `VRC UI Shape`s in the menu, 2 of which did not have a box collider on the object in the prefab yet - I've added them so we can configure them
- on these 3 colliders I've
  - set their `Exclude Layers` to `Everything`
  - set their `Layer Override Priority` to `10` for good measure
- I've tested this in VRChat and you can still interact with the menu, because raycasts and other physics checks from scripts don't care about collisions like that, they just check if an object's layer is part of the specified layer mask passed to that function

Now for the second change, I've added a non gravity, kinematic rigid body to all colliders in the menu (the 3 from before, and the collider under the player during no-clip). This marks them as dynamic and prevents static collision geometry caching from causing performance problems, in theory. See it's commit message.
If you don't trust it, perfectly fine, I (or you) can revert the commit.